### PR TITLE
Make action and guard template parameters

### DIFF
--- a/include/Hsm.h
+++ b/include/Hsm.h
@@ -84,13 +84,13 @@ struct IHsm : public State
 ///
 /// Implements a Hierarchical State Machine.
 ///
-template<typename HsmDef>
+template<typename HsmDef,
+         typename StateTransitionTable = StateTransitionTableT<HsmDef>>
 struct Hsm : public IHsm
 {
-    using StateTransitionTable = StateTransitionTableT<HsmDef>;
     using Transition = typename StateTransitionTableT<HsmDef>::Transition;
-    using ActionFn = void (HsmDef::*)();
-    using GuardFn = bool (HsmDef::*)();
+    using ActionFn = typename StateTransitionTable::ActionFn;
+    using GuardFn = typename StateTransitionTable::GuardFn;
 
     explicit Hsm(IHsm* parent = nullptr)
       : IHsm(parent)

--- a/include/Transition.h
+++ b/include/Transition.h
@@ -9,11 +9,13 @@
 #include <unordered_map>
 namespace tsm {
 
-template<typename FsmDef>
+template<typename FsmDef,
+         typename ActionFnT = void (FsmDef::*)(),
+         typename GuardFnT = bool (FsmDef::*)()>
 struct StateTransitionTableT
 {
-    using ActionFn = void (FsmDef::*)();
-    using GuardFn = bool (FsmDef::*)();
+    using ActionFn = ActionFnT;
+    using GuardFn = GuardFnT;
 
     struct Transition
     {


### PR DESCRIPTION
The StateTransitionTableT struct is now parameterized on the FsmDef,
action and guard functions. The user can provide custom types for these
functions. However, they apply to all transitions in the state
transition table.